### PR TITLE
feat: add chunking with smart generators

### DIFF
--- a/nvflare/app_opt/tensor_stream/receiver.py
+++ b/nvflare/app_opt/tensor_stream/receiver.py
@@ -62,7 +62,7 @@ class TensorReceiver:
             factory=TensorConsumerFactory(),
             stream_done_cb=self._save_tensors_cb,
         )
-        self.logger.info(
+        self.logger.debug(
             f"Registered tensor receiver for context property '{self.ctx_prop_key}' "
             f"on '{self.channel}:{topic}' with format '{self.format}'.",
         )


### PR DESCRIPTION
Improve performance while keeping memory usage low. By leveraging generators data flow is faster.

When doing IO the CPU bound code and prepare the next batch. Combined with chunking, it reduces CPU usage and latency.

When testing with 5000 tensors (2.2GB) it reduced transfer times from 70s to 30s.

Fixes # .

### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] Quick tests passed locally by running `./runtest.sh`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated.
